### PR TITLE
Add PowerShell passphrase generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 A collection of small scripts in different languages to generate random passphrases. Each implementation produces a passphrase made of random words, digits and special characters.
 
-The `bash` folder contains the reference Bash version.
+The `bash` folder contains the reference Bash version ([see documentation](bash/README.md)).

--- a/powershell/README.md
+++ b/powershell/README.md
@@ -1,0 +1,31 @@
+# PowerShell Passphrase Generator
+
+This folder contains a PowerShell script (`genPassphrase.ps1`) that generates random passphrases.
+
+## Usage
+
+Run the script with PowerShell:
+
+```powershell
+./genPassphrase.ps1 [-NumWords N] [-NumSpecials N] [-NumDigits N] [-AllowedSpecials SET] [-Separators SET] [-CaseProfile N]
+```
+
+Use `Get-Help ./genPassphrase.ps1 -Detailed` to see all available options.
+
+## Options
+
+- `-NumWords` – number of random words to include (default: `4`).
+- `-NumSpecials` – number of special characters used at the prefix and suffix (default: `2`).
+- `-NumDigits` – number of digits placed before and after the words (default: `2`).
+- `-AllowedSpecials` – characters that may appear as special characters (default: `!@#%&*`).
+- `-Separators` – possible separators between words; one character is chosen at random (default: `-_:.`).
+- `-CaseProfile` – choose a case transformation profile (default: `3`):
+  1. all lowercase
+  2. all uppercase
+  3. random case per word
+  4. one random letter uppercase per word
+  5. random case per letter
+
+## Description
+
+The script fetches random words from an online API, applies the selected case profile and mixes them with digits and special characters to build a symmetrical passphrase.

--- a/powershell/genPassphrase.ps1
+++ b/powershell/genPassphrase.ps1
@@ -1,0 +1,64 @@
+[CmdletBinding()]
+param(
+    [int]$NumWords = 4,
+    [int]$NumSpecials = 2,
+    [int]$NumDigits = 2,
+    [string]$AllowedSpecials = '!@#%&*',
+    [string]$Separators = '-_:.',
+    [ValidateSet(1,2,3,4,5)]
+    [int]$CaseProfile = 3
+)
+
+function Get-RandomChars {
+    param(
+        [string]$Set,
+        [int]$Count
+    )
+    $out = ''
+    for ($i = 0; $i -lt $Count; $i++) {
+        $out += $Set.Substring((Get-Random -Minimum 0 -Maximum $Set.Length),1)
+    }
+    return $out
+}
+
+$Words = Invoke-RestMethod -Uri "https://random-word-api.vercel.app/api?words=$NumWords"
+
+switch ($CaseProfile) {
+    1 { $Words = $Words | ForEach-Object { $_.ToLower() } }
+    2 { $Words = $Words | ForEach-Object { $_.ToUpper() } }
+    3 {
+        $Words = $Words | ForEach-Object {
+            if ((Get-Random -Minimum 0 -Maximum 2) -eq 0) { $_.ToLower() } else { $_.ToUpper() }
+        }
+    }
+    4 {
+        $Words = $Words | ForEach-Object {
+            $word = $_.ToLower()
+            $index = Get-Random -Minimum 0 -Maximum $word.Length
+            $word.Substring(0,$index) + $word[$index].ToString().ToUpper() + $word.Substring($index+1)
+        }
+    }
+    5 {
+        $Words = $Words | ForEach-Object {
+            ($_.ToCharArray() | ForEach-Object {
+                if ((Get-Random -Minimum 0 -Maximum 2) -eq 0) { $_.ToString().ToLower() } else { $_.ToString().ToUpper() }
+            }) -join ''
+        }
+    }
+}
+
+$Sep = $Separators[(Get-Random -Minimum 0 -Maximum $Separators.Length)]
+$JoinedWords = $Words -join $Sep
+
+$PrefixSpecials = Get-RandomChars -Set $AllowedSpecials -Count $NumSpecials
+$chars = $PrefixSpecials.ToCharArray()
+[array]::Reverse($chars)
+$SuffixSpecials = -join $chars
+
+$PrefixDigits = Get-RandomChars -Set '0123456789' -Count $NumDigits
+$SuffixDigits = Get-RandomChars -Set '0123456789' -Count $NumDigits
+
+$Passphrase = "$PrefixSpecials$PrefixDigits$Sep$JoinedWords$Sep$SuffixDigits$SuffixSpecials"
+
+Write-Output 'Generated passphrase:'
+Write-Output $Passphrase


### PR DESCRIPTION
## Summary
- link to the Bash documentation from the main README
- add a new PowerShell implementation that mirrors the Bash script
- document how to use the PowerShell version

## Testing
- `pwsh powershell/genPassphrase.ps1 -NumWords 1`
- `pwsh powershell/genPassphrase.ps1 -NumWords 2 -NumDigits 1 -NumSpecials 1`


------
https://chatgpt.com/codex/tasks/task_e_68779653a97883268480c11861968367